### PR TITLE
fix: 修改全选删除时，井号无法删除问题

### DIFF
--- a/src/utils/hasClass.ts
+++ b/src/utils/hasClass.ts
@@ -1,0 +1,4 @@
+export function hasClass(dom: Element, className: string) {
+  const classList = dom.getAttribute("class")?.split(" ");
+  return classList ? classList.includes(className) : false;
+}

--- a/src/view/base-view.ts
+++ b/src/view/base-view.ts
@@ -23,6 +23,8 @@ export class BaseView extends EventEmitter {
   protected selectionModel_: SelectionModel;
   protected viewContainer_: HTMLElement;
 
+  // 用于判断是否需要更新光标位置
+  private needUpdateSelection_: boolean = false;
   private renderBinder_: any;
   // private updateDomSelectionBinder_: any;
   private domSelectionChangeHandlerBinder_: any;
@@ -42,17 +44,16 @@ export class BaseView extends EventEmitter {
   /** 鼠标或键盘导致的原生 dom 选区变化，同步到选区模型 */
   domSelectionChangeHandler (e: Event) {
     const domSelection = window.getSelection();
-    const selectionFromModel = this.selectionModel_.getSelection();
     let selectionFromDom: SelectionCustom | null = null;
     if (domSelection) {
       selectionFromDom = this.domSelToCustomSel(domSelection);
-      /** 
-       * 如果即将更新到 dom 的选区和当前 dom 本身的选区一致，则不需操作dom。这里的判断逻辑是否影响光标操作体验待测试。
-       * 两个原因：1.避免冗余的dom操作；2.如果变化原因本身就是 dom 自身触发的，若数据模型再去触发 dom 更新，陷入循环
-       */
-      if (!SelectionModel.isEqual(selectionFromDom, selectionFromModel)) {
-        this.emit(BaseView.EVENT_TYPE.SELECTION_CHANGE, selectionFromDom);
-        this.updateDomSelection ()
+      this.showMarker(domSelection);
+      this.emit(BaseView.EVENT_TYPE.SELECTION_CHANGE, selectionFromDom);
+      // 判断当前是否需要改变光标位置
+      if( this.needUpdateSelection_ ) {
+        this.updateDomSelection();
+        // 重置状态
+        this.needUpdateSelection_ = false
       }
     }
   }
@@ -62,14 +63,11 @@ export class BaseView extends EventEmitter {
     // TODO 暂时不放timer里，到时测试一下性能
     const domSelection = window.getSelection();
     if (domSelection) {
-      // const selectionFromDom = this.domSelToCustomSel(domSelection);
       const selectionFromModel = this.selectionModel_.getSelection();
-      domSelection.removeAllRanges();
       const range = this.customSelToDomSel(selectionFromModel);
+      domSelection.removeAllRanges();
       if (range) {
         domSelection.addRange(range);
-        // 立即调用showmarker，避免在marker之间输入时，marker触发延时导致闪烁的问题
-        this.showMarker(domSelection);
       }
     }
   }
@@ -186,9 +184,12 @@ export class BaseView extends EventEmitter {
     const domOffset = domPoint.domOffset;
     const sourceIndex = this.getNodeSource_(domNode);
     let point = sourceIndex[0] + domOffset;
+    // 如果当前节点具有 marker，且当前光标选择首部（offset = 0），则更新光标位置为 marker 之前。
     if(domNode.previousElementSibling && hasClass(domNode.previousElementSibling, 'editor-marker') && domOffset === 0){
       const preSourceIndex = this.getNodeSource_(domNode.previousElementSibling  as HTMLElement);
-      point = preSourceIndex[0] + domOffset
+      point = preSourceIndex[0]
+      // 用于判断是否需要更新光标位置
+      this.needUpdateSelection_ = true
     }
     if (!(domNode instanceof Text) && domOffset > 0) { // domOffset>0 ,因此一定存在子元素
       const childNodes = domNode.childNodes;
@@ -317,8 +318,12 @@ export class BaseView extends EventEmitter {
     // console.error('customMark-Html', markdown.md2html(this.textModel_.getSpacer()))
     // console.timeEnd('customMark-time')
     // this.viewContainer_.innerHTML = this.textModel_.getSpacer()
+    const domSelection = window.getSelection();
     this.viewContainer_.innerHTML = markdown.md2html(this.textModel_.getSpacer())
+    // 更新光标位置
     this.updateDomSelection();
+    // 显示隐藏的 marker
+    this.showMarker(domSelection);
     // this.viewContainer_.scrollTop = this.viewContainer_.scrollHeight;
   }
 

--- a/src/view/base-view.ts
+++ b/src/view/base-view.ts
@@ -186,13 +186,27 @@ export class BaseView extends EventEmitter {
     const domOffset = domPoint.domOffset;
     const sourceIndex = this.getNodeSource_(domNode);
     let point = sourceIndex[0] + domOffset;
-    // 如果当前节点具有 marker，且当前光标选择首部（offset = 0），则更新光标位置为 marker 之前。
-    if(domNode.previousElementSibling && hasClass(domNode.previousElementSibling, 'editor-marker') && domOffset === 0){
-      const preSourceIndex = this.getNodeSource_(domNode.previousElementSibling  as HTMLElement);
-      point = preSourceIndex[0]
-      // 用于判断是否需要更新光标位置
-      this.needUpdateSelection_ = true
+    
+    /*
+     * 如果当前是文本节点，则判断文本之前的节点是否有 marker 节点（h1、h2、h3、h4、h5、h6）,否则判断父节点是否
+     * 有 marker 节点（a标签、strong标签等）
+     */
+    if (domNode instanceof Text) {
+      let elementDom: HTMLElement | null = null
+      if(domNode.previousElementSibling){
+        elementDom = domNode.previousElementSibling as HTMLElement
+      }else if(domNode.parentElement && domNode.parentElement.previousElementSibling){
+        elementDom = domNode.parentElement.previousElementSibling as HTMLElement
+      }
+      // 如果当前节点具有 marker，且当前光标选择首部（offset = 0），则更新光标位置为 marker 之前。
+      if(elementDom && hasClass(elementDom, 'editor-marker') && domOffset === 0){
+        const preSourceIndex = this.getNodeSource_(elementDom  as HTMLElement);
+        point = preSourceIndex[0]
+        // 用于判断是否需要更新光标位置
+        this.needUpdateSelection_ = true
+      }
     }
+    
     if (!(domNode instanceof Text) && domOffset > 0) { // domOffset>0 ,因此一定存在子元素
       const childNodes = domNode.childNodes;
       const domOffsetSourceIndex = this.getNodeSource_(childNodes[domOffset - 1] as HTMLElement);

--- a/src/view/base-view.ts
+++ b/src/view/base-view.ts
@@ -9,6 +9,7 @@ import EventEmitter from "events";
 import { Parser, HtmlRenderer } from "../markdown-parse/lib/index.js";
 import markdown from "../markdown-parse"
 import { debounce } from "../utils/debounce";
+import { hasClass } from "../utils/hasClass";
 
 export interface IDomPoint {
   domNode: HTMLElement;
@@ -199,7 +200,7 @@ export class BaseView extends EventEmitter {
     const sourceIndex = [0, 0];
     if (domNode instanceof Text) {
       const textL = domNode.length;
-      if (domNode.previousElementSibling) {
+      if (domNode.previousElementSibling && !hasClass(domNode.previousElementSibling, 'editor-marker')) {
         const preIndexStr = domNode.previousElementSibling.getAttribute('i');
         if (preIndexStr) {
           const preIndexRange = preIndexStr.split('-');

--- a/src/view/base-view.ts
+++ b/src/view/base-view.ts
@@ -44,11 +44,11 @@ export class BaseView extends EventEmitter {
   /** 鼠标或键盘导致的原生 dom 选区变化，同步到选区模型 */
   domSelectionChangeHandler (e: Event) {
     const domSelection = window.getSelection();
-    let selectionFromDom: SelectionCustom | null = null;
+    let selection: SelectionCustom | null = null;
     if (domSelection) {
-      selectionFromDom = this.domSelToCustomSel(domSelection);
+      selection = this.domSelToCustomSel(domSelection);
       this.showMarker(domSelection);
-      this.emit(BaseView.EVENT_TYPE.SELECTION_CHANGE, selectionFromDom);
+      this.emit(BaseView.EVENT_TYPE.SELECTION_CHANGE, selection);
       // 判断当前是否需要改变光标位置
       if( this.needUpdateSelection_ ) {
         this.updateDomSelection();
@@ -68,6 +68,8 @@ export class BaseView extends EventEmitter {
       domSelection.removeAllRanges();
       if (range) {
         domSelection.addRange(range);
+        // updateDomSelection 方法只负责更新光标位置，更新 marker 逻辑放在外面。
+        // this.showMarker(domSelection)
       }
     }
   }

--- a/src/view/base-view.ts
+++ b/src/view/base-view.ts
@@ -186,7 +186,7 @@ export class BaseView extends EventEmitter {
     const domOffset = domPoint.domOffset;
     const sourceIndex = this.getNodeSource_(domNode);
     let point = sourceIndex[0] + domOffset;
-    if(domNode.previousElementSibling && hasClass(domNode.previousElementSibling, 'editor-marker')&& domOffset === 0){
+    if(domNode.previousElementSibling && hasClass(domNode.previousElementSibling, 'editor-marker') && domOffset === 0){
       const preSourceIndex = this.getNodeSource_(domNode.previousElementSibling  as HTMLElement);
       point = preSourceIndex[0] + domOffset
     }


### PR DESCRIPTION
https://github.com/Ben-love-zy/web-editor-markdown/issues/16#issue-1483177160

改动点：
1. 修改在 RENDER MODE 模式中使用全选时，首行标题井号无法删除问题，在 getNodeSource_ 方法中判断是否有文本标记符（.editor-marker），如果有则取父节点的 preIndexStr

开发逻辑：
当选中节点具有 marker 时，如果光标在节点开头（offset = 0），则将光标位置重置为 marker 之前。由于重置光标会触发 selectionchange 事件，需要进行判断如果即将更新到 dom 的选区和当前 dom 本身的选区一致，则不需操作dom。

影响范围：
1. src/view/base-view.ts: 203
3. src/utils/hasClass.ts


发布时间：
2023.4.4